### PR TITLE
Upgrade stackage / work with latest messagepack

### DIFF
--- a/library/Neovim.hs
+++ b/library/Neovim.hs
@@ -277,7 +277,7 @@ which GHC should point you to.
 
 
 -- | Default configuration options for /nvim-hs/. If you want to keep the
--- default plugins enabled, you can define you rconfig like this:
+-- default plugins enabled, you can define your config like this:
 --
 -- @
 -- main = 'neovim' 'defaultConfig'
@@ -329,10 +329,10 @@ project once they are mature enough. This also makes them easy to share!
 -- Creating a plugin {{{2
 {- $creatingplugins
 Creating plugins isn't difficult either. You just have to follow and survive the
-the compile time errors of seemingly valid code. This may
-sound scary, but it is not so bad. We will cover most pitfalls in the following
-paragraphs and if there isn't a solution for your error, you can always ask any
-friendly Haskeller in \#haskell on @irc.freenode.net@!
+compile time errors of seemingly valid code. This may sound scary, but it is not
+so bad. We will cover most pitfalls in the following paragraphs and if there
+isn't a solution for your error, you can always ask any friendly Haskeller in
+\#haskell on @irc.freenode.net@!
 
 Enough scary stuff said for now, let's write a plugin!
 Due to a stage restriction in GHC when using Template Haskell, we must define

--- a/library/Neovim/Classes.hs
+++ b/library/Neovim/Classes.hs
@@ -90,6 +90,7 @@ instance NvimObject Bool where
 
     fromObject (ObjectBool o)     = return o
     fromObject (ObjectInt  0)     = return False
+    fromObject (ObjectUInt 0)     = return False
     fromObject ObjectNil          = return False
     fromObject (ObjectBinary "0") = return False
     fromObject (ObjectBinary "")  = return False
@@ -104,6 +105,7 @@ instance NvimObject Double where
     fromObject (ObjectDouble o) = return o
     fromObject (ObjectFloat o)  = return $ realToFrac o
     fromObject (ObjectInt o)    = return $ fromIntegral o
+    fromObject (ObjectUInt o)   = return $ fromIntegral o
     fromObject o                = throwError . text $ "Expected ObjectDouble, but got " <> show o
 
 
@@ -111,6 +113,7 @@ instance NvimObject Integer where
     toObject                    = ObjectInt . fromIntegral
 
     fromObject (ObjectInt o)    = return $ toInteger o
+    fromObject (ObjectUInt o)   = return $ toInteger o
     fromObject (ObjectDouble o) = return $ round o
     fromObject (ObjectFloat o)  = return $ round o
     fromObject o                = throwError . text $ "Expected ObjectInt, but got " <> show o
@@ -120,6 +123,7 @@ instance NvimObject Int64 where
     toObject                    = ObjectInt
 
     fromObject (ObjectInt i)    = return i
+    fromObject (ObjectUInt o)   = return $ fromIntegral o
     fromObject (ObjectDouble o) = return $ round o
     fromObject (ObjectFloat o)  = return $ round o
     fromObject o                = throwError . text $ "Expected any Integer value, but got " <> show o
@@ -129,6 +133,7 @@ instance NvimObject Int32 where
     toObject                    = ObjectInt . fromIntegral
 
     fromObject (ObjectInt i)    = return $ fromIntegral i
+    fromObject (ObjectUInt i)   = return $ fromIntegral i
     fromObject (ObjectDouble o) = return $ round o
     fromObject (ObjectFloat o)  = return $ round o
     fromObject o                = throwError . text $ "Expected any Integer value, but got " <> show o
@@ -138,6 +143,7 @@ instance NvimObject Int16 where
     toObject                    = ObjectInt . fromIntegral
 
     fromObject (ObjectInt i)    = return $ fromIntegral i
+    fromObject (ObjectUInt i)   = return $ fromIntegral i
     fromObject (ObjectDouble o) = return $ round o
     fromObject (ObjectFloat o)  = return $ round o
     fromObject o                = throwError . text $ "Expected any Integer value, but got " <> show o
@@ -147,6 +153,7 @@ instance NvimObject Int8 where
     toObject                    = ObjectInt . fromIntegral
 
     fromObject (ObjectInt i)    = return $ fromIntegral i
+    fromObject (ObjectUInt i)   = return $ fromIntegral i
     fromObject (ObjectDouble o) = return $ round o
     fromObject (ObjectFloat o)  = return $ round o
     fromObject o                = throwError . text $ "Expected any Integer value, but got " <> show o
@@ -156,6 +163,7 @@ instance NvimObject Word where
     toObject                    = ObjectInt . fromIntegral
 
     fromObject (ObjectInt i)    = return $ fromIntegral i
+    fromObject (ObjectUInt i)   = return $ fromIntegral i
     fromObject (ObjectDouble o) = return $ round o
     fromObject (ObjectFloat o)  = return $ round o
     fromObject o                = throwError . text $ "Expected any Integer value, but got " <> show o
@@ -165,6 +173,7 @@ instance NvimObject Word64 where
     toObject                    = ObjectInt . fromIntegral
 
     fromObject (ObjectInt i)    = return $ fromIntegral i
+    fromObject (ObjectUInt i)   = return $ fromIntegral i
     fromObject (ObjectDouble o) = return $ round o
     fromObject (ObjectFloat o)  = return $ round o
     fromObject o                = throwError . text $ "Expected any Integer value, but got " <> show o
@@ -174,6 +183,7 @@ instance NvimObject Word32 where
     toObject                    = ObjectInt . fromIntegral
 
     fromObject (ObjectInt i)    = return $ fromIntegral i
+    fromObject (ObjectUInt i)   = return $ fromIntegral i
     fromObject (ObjectDouble o) = return $ round o
     fromObject (ObjectFloat o)  = return $ round o
     fromObject o                = throwError . text $ "Expected any Integer value, but got " <> show o
@@ -183,6 +193,7 @@ instance NvimObject Word16 where
     toObject                    = ObjectInt . fromIntegral
 
     fromObject (ObjectInt i)    = return $ fromIntegral i
+    fromObject (ObjectUInt i)   = return $ fromIntegral i
     fromObject (ObjectDouble o) = return $ round o
     fromObject (ObjectFloat o)  = return $ round o
     fromObject o                = throwError . text $ "Expected any Integer value, but got " <> show o
@@ -192,6 +203,7 @@ instance NvimObject Word8 where
     toObject                    = ObjectInt . fromIntegral
 
     fromObject (ObjectInt i)    = return $ fromIntegral i
+    fromObject (ObjectUInt i)   = return $ fromIntegral i
     fromObject (ObjectDouble o) = return $ round o
     fromObject (ObjectFloat o)  = return $ round o
     fromObject o                = throwError . text $ "Expected any Integer value, but got " <> show o
@@ -201,6 +213,7 @@ instance NvimObject Int where
     toObject                    = ObjectInt . fromIntegral
 
     fromObject (ObjectInt i)    = return $ fromIntegral i
+    fromObject (ObjectUInt i)   = return $ fromIntegral i
     fromObject (ObjectDouble o) = return $ round o
     fromObject (ObjectFloat o)  = return $ round o
     fromObject o                = throwError . text $ "Expected any Integer value, but got " <> show o

--- a/nvim-hs.cabal
+++ b/nvim-hs.cabal
@@ -107,7 +107,7 @@ library
                       , filepath
                       , foreign-store
                       , hslogger
-                      , messagepack >= 0.4
+                      , messagepack >= 0.5
                       , monad-control
                       , network
                       , lifted-base
@@ -159,7 +159,7 @@ test-suite hspec
                       , hslogger
                       , lifted-base
                       , mtl >= 2.2.1 && < 2.3
-                      , messagepack >= 0.4
+                      , messagepack >= 0.5
                       , time-locale-compat
                       , network
                       , optparse-applicative

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,4 +5,4 @@ extra-deps:
         - dyre-0.8.12
         - io-storage-0.3
         - xdg-basedir-0.2.2
-resolver: lts-3.2
+resolver: lts-6.2

--- a/test-suite/Neovim/Plugin/ClassesSpec.hs
+++ b/test-suite/Neovim/Plugin/ClassesSpec.hs
@@ -55,7 +55,7 @@ instance Arbitrary RandomCommandOptions where
 
 spec :: Spec
 spec = do
-  describe "Deserializing ans serializing" $ do
+  describe "Deserializing and serializing" $ do
     it "should be id for CommandArguments" . property $ do
       \args -> (fromObjectUnsafe . toObject . getRandomCommandArguments) args
         `shouldBe` getRandomCommandArguments args


### PR DESCRIPTION
It turns out the issue (#44) only appeared because I had not followed the instructions but used `stack install nvim-hs` with the global resolver.

Nevertheless, I hope this change will be useful. It upgrades stackage to [lts-6.2](https://www.stackage.org/lts-6.2), since the one referenced in the project's stack.yml doesn't feature messagepack >= 0.5.