### PR TITLE
nvim-hs is now in stackage - simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,27 +57,6 @@ you have to create your plugin project.
 
 > stack new my-nvim-hs https://raw.githubusercontent.com/neovimhaskell/nvim-hs/master/stack-template.hsfiles --bare --omit-packages --ignore-subdirs
 
-Since `nvim-hs` is not yet on stackage, you have to edit the generated
-`stack.yaml` file by hand (sorry about that). Replace the packages list with
-one containing the current directory and the extra-deps list with a
-dependency to nvim-hs. The lines of the file that look like this
-
-```yaml
-packages: []
-
-extra-deps: []
-```
-
-should become:
-
-```yaml
-packages:
-- .
-
-extra-deps:
-- nvim-hs-0.2.2
-```
-
 Now, you have to compile everything.
 
 > stack setup


### PR DESCRIPTION
Removes section on adding `nvim-hs-0.2.2` to `stack.yaml`. Addresses issue #59.

There are other descriptions of adding things to `extra-deps` in `stack.yaml` elsewhere in the README, but those seem to be self-contained. (I'm not sure if those can also be removed though; I'm a newbie to `nvim-hs`.)