### PR TITLE
Add flushing to handles (fixes #61)

### DIFF
--- a/library/Neovim/API/Parser.hs
+++ b/library/Neovim/API/Parser.hs
@@ -169,7 +169,7 @@ pVoid = const Void <$> (P.try (string "void") <* eof)
 
 
 pSimple :: P.Parser NeovimType
-pSimple = SimpleType <$> some (noneOf [',', ')'])
+pSimple = SimpleType <$> P.some (noneOf [',', ')'])
 
 
 pArray :: P.Parser NeovimType
@@ -178,5 +178,5 @@ pArray = NestedType <$> (P.try (string "ArrayOf(") *> pType)
 
 
 pNum :: P.Parser Int
-pNum = read <$> (P.try (char ',') *> space *> some (oneOf ['0'..'9']))
+pNum = read <$> (P.try (char ',') *> space *> P.some (oneOf ['0'..'9']))
 

--- a/library/Neovim/Plugin/ConfigHelper/Internal.hs
+++ b/library/Neovim/Plugin/ConfigHelper/Internal.hs
@@ -81,17 +81,17 @@ restartNvimhs CommandArguments{..} = do
 -- error messages look like.
 parseQuickfixItems :: String -> [QuickfixListItem String]
 parseQuickfixItems s =
-    case parse (many pQuickfixListItem) "Quickfix parser" s of
+    case parse (P.many pQuickfixListItem) "Quickfix parser" s of
         Right qs -> qs
         Left _   -> []
 
 
 pQuickfixListItem :: P.Parser (QuickfixListItem String)
 pQuickfixListItem = do
-    _ <- many blankLine
+    _ <- P.many blankLine
     (f,l,c) <- pLocation
 
-    void $ many tabOrSpace
+    void $ P.many tabOrSpace
     e <- pSeverity
     desc <- try pShortDesrciption <|> pLongDescription
     return $ (quickfixListItem (Right f) (Left l))
@@ -109,7 +109,7 @@ pSeverity = do
 pShortDesrciption :: P.Parser String
 pShortDesrciption = (:)
     <$> (notFollowedBy blankLine *> anyChar)
-    <*> anyChar `manyTill` (void (some blankLine) <|> eof)
+    <*> anyChar `manyTill` (void (P.some blankLine) <|> eof)
 
 
 pLongDescription :: P.Parser String
@@ -123,7 +123,7 @@ tabOrSpace = satisfy $ \c -> c == ' ' || c == '\t'
 
 
 blankLine :: P.Parser ()
-blankLine = void . try $ many tabOrSpace >> newline
+blankLine = void . try $ P.many tabOrSpace >> newline
 
 
 -- | Skip anything until the next location information appears.
@@ -135,11 +135,11 @@ blankLine = void . try $ many tabOrSpace >> newline
 -- @\/some\/path\/to\/a\/file.hs:42:88:@
 pLocation :: P.Parser (String, Int, Int)
 pLocation = (,,)
-    <$> some (noneOf ":\n\t\r") <* char ':'
+    <$> P.some (noneOf ":\n\t\r") <* char ':'
     <*> pInt <* char ':'
-    <*> pInt <* char ':' <* many tabOrSpace
+    <*> pInt <* char ':' <* P.many tabOrSpace
 
 
 pInt :: P.Parser Int
-pInt = read <$> some (satisfy isDigit)
+pInt = read <$> P.some (satisfy isDigit)
 -- 1}}}

--- a/nvim-hs.cabal
+++ b/nvim-hs.cabal
@@ -100,7 +100,16 @@ library
                       , cereal
                       , cereal-conduit >= 0.7.3
                       , conduit
-                      , conduit-extra
+
+                      -- sinkHandle flushed after every yield in the releases
+                      -- [1.1.2, 1.1.17) and in release 1.2.2 an API was added
+                      -- to flush manually, so any other version probably does
+                      -- not work unless you set NoBuffering on the handle (see #61)
+                      -- I think having NoBuffering on TCP-Handles is kind of
+                      -- ridicilous, so the version range [1.1.17, 1.2.2) is
+                      -- simply excluded
+                      , conduit-extra >= 1.1.2 && < 1.1.17 || >= 1.2.2
+
                       , containers
                       , data-default
                       , deepseq >= 1.1 && < 1.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 flags: {}
 packages:
 - '.'
-resolver: nightly-2017-07-31
+resolver: lts-10.1
 extra-deps: []


### PR DESCRIPTION
Setting `stdout` to not use buffering explicitly seems to be necessary now for some reason.