### PR TITLE
Prefix rpc method names with the functionality type

### DIFF
--- a/library/Neovim/API/TH.hs
+++ b/library/Neovim/API/TH.hs
@@ -391,7 +391,7 @@ classifyArgType t = do
 command :: String -> Name -> Q Exp
 command [] _ = error "Empty names are not allowed for exported commands."
 command customFunctionName@(c:_) functionName
-    | (not . isUpper) c = error $ "Custom command name must start with a capiatl letter: " <> show customFunctionName
+    | (not . isUpper) c = error $ "Custom command name must start with a capital letter: " <> show customFunctionName
     | otherwise = do
         (argTypes, fun) <- functionImplementation functionName
         -- See :help :command-nargs for what the result strings mean

--- a/library/Neovim/Context/Internal.hs
+++ b/library/Neovim/Context/Internal.hs
@@ -168,12 +168,12 @@ type FunctionMapEntry = (FunctionalityDescription, FunctionType)
 -- a thread that reads from a 'TQueue'. (NB: persistent currently means, that
 -- state is stored for as long as the plugin provider is running and not
 -- restarted.)
-type FunctionMap = Map FunctionName FunctionMapEntry
+type FunctionMap = Map NvimMethod FunctionMapEntry
 
 
 -- | Create a new function map from the given list of 'FunctionMapEntry' values.
 mkFunctionMap :: [FunctionMapEntry] -> FunctionMap
-mkFunctionMap = Map.fromList . map (\e -> (F (methodName (fst e)), e))
+mkFunctionMap = Map.fromList . map (\e -> (nvimMethod (fst e), e))
 
 
 -- | A wrapper for a reader value that contains extra fields required to
@@ -238,10 +238,10 @@ data PluginSettings env where
         :: (FunctionalityDescription
             -> ([Object] -> Neovim env Object)
             -> TQueue SomeMessage
-            -> TVar (Map FunctionName ([Object] -> Neovim env Object))
+            -> TVar (Map NvimMethod ([Object] -> Neovim env Object))
             -> Neovim env (Maybe FunctionMapEntry))
         -> TQueue SomeMessage
-        -> TVar (Map FunctionName ([Object] -> Neovim env Object))
+        -> TVar (Map NvimMethod ([Object] -> Neovim env Object))
         -> PluginSettings env
 
 

--- a/library/Neovim/Context/Internal.hs
+++ b/library/Neovim/Context/Internal.hs
@@ -173,7 +173,7 @@ type FunctionMap = Map FunctionName FunctionMapEntry
 
 -- | Create a new function map from the given list of 'FunctionMapEntry' values.
 mkFunctionMap :: [FunctionMapEntry] -> FunctionMap
-mkFunctionMap = Map.fromList . map (\e -> (name (fst e), e))
+mkFunctionMap = Map.fromList . map (\e -> (F (methodName (fst e)), e))
 
 
 -- | A wrapper for a reader value that contains extra fields required to

--- a/library/Neovim/Plugin/Classes.hs
+++ b/library/Neovim/Plugin/Classes.hs
@@ -439,6 +439,7 @@ instance NvimObject AutocmdOptions where
 -- | Conveniennce class to extract a name from some value.
 class HasFunctionName a where
     name :: a -> FunctionName
+    methodName :: a -> ByteString
 
 
 instance HasFunctionName FunctionalityDescription where
@@ -447,3 +448,7 @@ instance HasFunctionName FunctionalityDescription where
         Command   n _ -> n
         Autocmd _ n _ _ -> n
 
+    methodName = \case
+        Function (F n) _ -> "function:" <> n
+        Command (F n) _ -> "command:" <> n
+        Autocmd _ (F n) _ _ -> n

--- a/library/Neovim/Plugin/Classes.hs
+++ b/library/Neovim/Plugin/Classes.hs
@@ -462,6 +462,6 @@ instance HasFunctionName FunctionalityDescription where
         Autocmd _ n _ _ -> n
 
     nvimMethod = \case
-        Function (F n) _ -> NvimMethod $ "function:" <> n
-        Command (F n) _ -> NvimMethod $ "command:" <> n
+        Function (F n) _ -> NvimMethod $ n <> ":function"
+        Command (F n) _ -> NvimMethod $ n <> ":command"
         Autocmd _ (F n) _ _ -> NvimMethod n

--- a/library/Neovim/Plugin/Internal.hs
+++ b/library/Neovim/Plugin/Internal.hs
@@ -43,7 +43,7 @@ getFunction (EF (_, f)) = f
 
 instance HasFunctionName (ExportedFunctionality env) where
     name = name . getDescription
-    methodName = methodName . getDescription
+    nvimMethod = nvimMethod . getDescription
 
 
 -- | This data type contains meta information for the plugin manager.

--- a/library/Neovim/Plugin/Internal.hs
+++ b/library/Neovim/Plugin/Internal.hs
@@ -43,6 +43,7 @@ getFunction (EF (_, f)) = f
 
 instance HasFunctionName (ExportedFunctionality env) where
     name = name . getDescription
+    methodName = methodName . getDescription
 
 
 -- | This data type contains meta information for the plugin manager.

--- a/library/Neovim/RPC/SocketReader.hs
+++ b/library/Neovim/RPC/SocketReader.hs
@@ -22,6 +22,7 @@ import qualified Neovim.Context.Internal    as Internal
 import           Neovim.Plugin.Classes      (CommandArguments (..),
                                              CommandOption (..),
                                              FunctionName (..),
+                                             NvimMethod (..),
                                              FunctionalityDescription (..),
                                              getCommandOptions)
 import           Neovim.Plugin.IPC.Classes
@@ -105,7 +106,7 @@ handleResponse i result = do
 -- function call identifier.
 handleRequestOrNotification :: Maybe Int64 -> FunctionName -> [Object]
                             -> ConduitT a Void SocketHandler ()
-handleRequestOrNotification requestId functionToCall params = do
+handleRequestOrNotification requestId functionToCall@(F functionName) params = do
     cfg <- lift Internal.ask'
     void . liftIO . async $ race logTimeout (handle cfg)
     return ()
@@ -114,7 +115,7 @@ handleRequestOrNotification requestId functionToCall params = do
     lookupFunction
         :: TMVar Internal.FunctionMap
         -> STM (Maybe (FunctionalityDescription, Internal.FunctionType))
-    lookupFunction funMap = Map.lookup functionToCall <$> readTMVar funMap
+    lookupFunction funMap = Map.lookup (NvimMethod functionName) <$> readTMVar funMap
 
     logTimeout :: IO ()
     logTimeout = do

--- a/test-suite/Neovim/API/THSpec.hs
+++ b/test-suite/Neovim/API/THSpec.hs
@@ -18,8 +18,6 @@ import qualified Data.Map                   as Map
 import           Test.Hspec
 import           Test.QuickCheck
 
-import           Control.Applicative
-
 call :: ([Object] -> Neovim () Object) -> [Object]
      -> IO Object
 call f args = do
@@ -73,7 +71,7 @@ spec = do
 
 
   describe "generating a command from the two argument test function" $ do
-      let EF (Command fname _, testFun) = $(command' 'testFunction2) []
+      let EF (Command fname _, _) = $(command' 'testFunction2) []
       it "should capitalize the first character" $
         fname `shouldBe` (F "TestFunction2")
 
@@ -111,7 +109,7 @@ spec = do
     it "should capitalize the first letter" $
         cname `shouldBe` (F "TestCommandOptArgument")
 
-    it "should return \"defalt\" when passed no argument" $ do
+    it "should return \"default\" when passed no argument" $ do
         call testFun [defCmdArgs] `shouldReturn` toObject ("default" :: String)
 
     it "should return what is passed otherwise" . property $ do

--- a/test-suite/Neovim/Plugin/ClassesSpec.hs
+++ b/test-suite/Neovim/Plugin/ClassesSpec.hs
@@ -39,7 +39,7 @@ instance Arbitrary RandomCommandOption where
             2 -> return $ CmdNargs ""
             3 -> CmdRange <$> elements [CurrentLine, WholeFile, RangeCount 1]
             4 -> CmdCount <$> arbitrary
-            5 -> return CmdBang
+            _ -> return CmdBang
         return $ RCO o
 
 

--- a/test-suite/Neovim/RPC/SocketReaderSpec.hs
+++ b/test-suite/Neovim/RPC/SocketReaderSpec.hs
@@ -4,11 +4,9 @@ module Neovim.RPC.SocketReaderSpec
 
 import           Neovim
 import           Neovim.Plugin.Classes
-import           Neovim.RPC.Common
 import           Neovim.RPC.SocketReader (parseParams)
 
 import           Test.Hspec
-import           Test.QuickCheck
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
Since the method name is used to look up rpc handlers, there cannot be a
function and a command with the same name.
This uses `command:` and `function:` as prefixes.