### PR TITLE
[WIP] Documentation Update

### DIFF
--- a/library/Neovim.hs
+++ b/library/Neovim.hs
@@ -153,11 +153,11 @@ just keep reading. @:-)@
 {- $existingplugins
 The easiest way to start is to use the stack template as described in the
 @README.md@ of this package. If you initialize it in your neovim configuration
-directory (@~/.convig/nvim@ on linux-based systems), it should automatically be
-compiled and run with two simple example plugins
+directory (@~/.config/nvim@ on linux-based systems), it should automatically be
+compiled and run with two simple example plugins.
 
 You have to define a haskell project that depends on this package and
-contains an executable secion with a main file that looks like this:
+contains an executable secion within a main file that looks something like this:
 
 @
 import TestPlugin.ExamplePlugin (examplePlugin)
@@ -171,8 +171,8 @@ main = 'neovim' 'def'
 /nvim-hs/ is all about importing and creating plugins. This is done following a
 concise API. Let's start by making a given plugin available inside
 our plugin provider. Assuming that we have installed a cabal package that exports
-an @examplePlugin@ from the module @TestPlugin.ExamplePlugin@. A minimal
-main file would then look like this:
+an @examplePlugin@ from the module @TestPlugin.ExamplePlugin@, a minimal
+main file would look something like this:
 
 That's all you have to do! Multiple plugins are simply imported and put in a
 list.

--- a/library/Neovim.hs
+++ b/library/Neovim.hs
@@ -153,7 +153,7 @@ just keep reading. @:-)@
 {- $existingplugins
 The easiest way to start is to use the stack template as described in the
 @README.md@ of this package. If you initialize it in your neovim configuration
-directory (@~/.config/nvim@ on linux-based systems), it should automatically be
+directory (@~\/.config\/nvim@ on linux-based systems), it should automatically be
 compiled and run with two simple example plugins.
 
 You have to define a haskell project that depends on this package and


### PR DESCRIPTION
I've made just a few small changes so far, but I'll try and proofread the rest of the docs later (and look in more detail at Neovim.hs), hopefully in a day or so.

Having started writing a plugin with this library, one thing I've noticed is that [the documentation for creating a plugin](https://hackage.haskell.org/package/nvim-hs-2.1.0.4/docs/Neovim.html#g:4) is a little confusing to me. I think it might be more useful to show how to make a plugin in a completely separate directory, say `/home/<user>/haskell-projects/my-vim-plugin`, and then use `Plug '/home/<user>/haskell-projects/my-vim-plugin'` (or the equivalent for other package managers) to test it. That way the requirement of having a git repo (see https://github.com/neovimhaskell/nvim-hs.vim/issues/7#issuecomment-655709070) is nicer to deal with, since having a git repo in the plugin directory (instead of `~/.config/nvim`) makes sense and is probably wanted anyways; and since plugin authors would probably want to create the plugin in a separate directory, it might be more practical. Thoughts?

Also, it isn't super clear to me the reason `~/.config/nvim/nvim.hs` exists or needs to exist. I've been able to `Plug` my plugin and use it without that file existing in `~/.config/nvim`, and so I'm not really sure why it exists. I don't know if that's something that should be explained in the Hackage docs or in the README, but I'd like to update that here if possible. I'm just not sure exactly what to do about that. So any help would be really appreciated ;-) (I apologize if I missed the explanation in the docs somewhere; if it does exist I just haven't seen it.)

Side note, thank you all for the work you've done and do on this library! It's really cool, and I enjoy being able to extend Neovim using Haskell! ;-)