### PR TITLE
fix missing arg to plainTV'

### DIFF
--- a/library/Neovim/API/TH.hs
+++ b/library/Neovim/API/TH.hs
@@ -85,7 +85,7 @@ plainTV' :: Name -> TyVarBndr Specificity
 plainTV' env = PlainTV env SpecifiedSpec
 #else
 plainTV' :: Name -> TyVarBndr
-plainTV' = PlainTV env
+plainTV' env = PlainTV env
 #endif
 
 -- | Generate the API types and functions provided by @nvim --api-info@.


### PR DESCRIPTION
fixes building nvim-hs with `template-haskell < 2.17.0`