### PR TITLE
Remove mechanism suppressing exceptions from RPC calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2.2.0.0
+
+* NeovimException are now thrown from (synchronous) remote functions and are no
+  longer suppressed with an `error` call that also had a terrible error message.
+  A function `catchNeovimException` (specialized `catch`) has been added that 
+  catches these errors. 
+* The return type of asynchronous functions is now alwas 
+  `STM (Either NeovimException result)` and errors have to be handled by the 
+  caller explicitly.
+
 # 2.1.0.2
 
 * Exported functions and commands now can have the same name.

--- a/library/Neovim.hs
+++ b/library/Neovim.hs
@@ -63,6 +63,7 @@ module Neovim (
     wait',
     err,
     errOnInvalidResult,
+    catchNeovimException,
     NeovimException(..),
 
     -- * Unsorted exports
@@ -107,6 +108,7 @@ import           Neovim.Context               (Neovim,
                                                ask, asks, err,
                                                errOnInvalidResult)
 import           Neovim.Main                  (neovim)
+import           Neovim.Exceptions            (catchNeovimException)
 import           Neovim.Plugin                (addAutocmd)
 import           Neovim.Plugin.Classes        (AutocmdOptions (..),
                                                CommandArguments (..),

--- a/library/Neovim/API/TH.hs
+++ b/library/Neovim/API/TH.hs
@@ -20,6 +20,7 @@ module Neovim.API.TH (
     stringListTypeMap,
     textVectorTypeMap,
     bytestringVectorTypeMap,
+    createFunction,
     module UnliftIO.Exception,
     module Neovim.Classes,
     module Data.Data,
@@ -172,11 +173,11 @@ apiTypeToHaskellType typeMap@TypeMap{typesOfAPI, list} at = case at of
 createFunction :: TypeMap -> NeovimFunction -> Q [Dec]
 createFunction typeMap nf = do
     let withDeferred
-            | async nf = appT [t|STM|]
+            | async nf = appT [t|STM|] . appT [t|Either NeovimException|]
             | otherwise = id
 
         callFn
-            | async nf = [|acall'|]
+            | async nf = [|acall|]
             | otherwise = [|scall'|]
 
         functionName = mkName $ name nf

--- a/nvim-hs.cabal
+++ b/nvim-hs.cabal
@@ -1,5 +1,5 @@
 name:                nvim-hs
-version:             2.1.0.7
+version:             2.2.0.0
 synopsis:            Haskell plugin backend for neovim
 description:
   This package provides a plugin provider for neovim. It allows you to write


### PR DESCRIPTION
Instead of calling error with an unhelpful message, simply throw the NeovimException.
The method, which has thrown the excpetion, has been added to the exception object.

A helper function `catchNeovimException` has been added which is simply
a specialization of the normal `catch`.

The unhelpful error message was a remnant of a refactor which removed
error types from the remote functions because all remote functions can fail.

See #94 