### PR TITLE
Move forall binder to front of generated types

### DIFF
--- a/src/Neovim/API/TH.hs
+++ b/src/Neovim/API/TH.hs
@@ -184,10 +184,8 @@ createFunction typeMap nf = do
         functionName = mkName $ name nf
         toObjVar v = [|toObject $(varE v)|]
 
-    retType <-
-        let env = mkName "env"
-         in forallT [specifiedPlainTV env] (return [])
-                . appT [t|Neovim $(varT env)|]
+    let env = mkName "env"
+    retType <- appT [t|Neovim $(varT env)|]
                 . withDeferred
                 . apiTypeToHaskellType typeMap
                 $ returnType nf
@@ -211,7 +209,9 @@ createFunction typeMap nf = do
             $ applyPrefixWithNumber nf
 
     sequence
-        [ (sigD functionName . return) (foldr ((AppT . AppT ArrowT) . fst) retType vars)
+        [ (sigD functionName . return)
+            . ForallT [specifiedPlainTV env] []
+            $ foldr ((AppT . AppT ArrowT) . fst) retType vars
         , funD
             functionName
             [ clause


### PR DESCRIPTION
This PR changes the types of the generated API from, eg:

```haskell
nvim_set_option :: String -> Object -> forall env. Neovim env ()
```

to

```haskell
nvim_set_option :: forall env. String -> Object -> Neovim env ()
```

which GHC likes much better in the light of simplified subsumption. Using these types means we can continue working with the nvim-hs API in pointfree fashion.